### PR TITLE
Add $ACLOCAL_FLAGS to autoreconf for Ubuntu 14.04.

### DIFF
--- a/macros/mate-autogen
+++ b/macros/mate-autogen
@@ -461,7 +461,7 @@ for configure_ac in $configure_files; do
 	fi
 	# Now that all the macros are sorted, run autoreconf ...
 	printbold "Running autoreconf..."
-	autoreconf --verbose --force --install -Wno-portability || exit 1
+	autoreconf ${ACLOCAL_FLAGS} --verbose --force --install -Wno-portability || exit 1
 
 	cd "$topdir"
     fi


### PR DESCRIPTION
This is necessary in Ubuntu 14.04 in order to build and install MATE components in /usr/local.
export ACLOCAL_FLAGS="-I /usr/local/share/aclocal/"
./autogen.sh --prefix=/usr/local --sysconfdir=/usr/local/etc --localstatedir=/var
