### PR TITLE
Check if AX_APPEND_FLAG and AX_CHECK_COMPILE_FLAG are available

### DIFF
--- a/macros/mate-compiler-flags.m4
+++ b/macros/mate-compiler-flags.m4
@@ -23,6 +23,14 @@ AC_DEFUN([MATE_COMPILE_WARNINGS],[
     dnl More compiler warnings
     dnl ******************************
 
+    m4_ifndef([AX_CHECK_COMPILE_FLAG],[
+        AC_MSG_ERROR([You need to install the autoconf-archive package.])
+    ])
+
+    m4_ifndef([AX_APPEND_FLAG],[
+        AC_MSG_ERROR([You need to install the autoconf-archive package.])
+    ])
+
     AC_ARG_ENABLE(compile-warnings,
                   AS_HELP_STRING([--enable-compile-warnings=@<:@no/minimum/yes/maximum/error@:>@],
                                  [Turn on compiler warnings]),,


### PR DESCRIPTION
Print the error message "You need to install the autoconf-archive
package." if autoconf archive macros are not available on the
system.

It's similar to [AX_REQUIRE_DEFINED](http://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=blob_plain;f=m4/ax_require_defined.m4)