### PR TITLE
silent -Wunused-parameter for maximum warning level

### DIFF
--- a/macros/mate-compiler-flags.m4
+++ b/macros/mate-compiler-flags.m4
@@ -49,7 +49,7 @@ AC_DEFUN([MATE_COMPILE_WARNINGS],[
 	warning_flags="-Wall -Wmissing-prototypes"
 	;;
     maximum|error)
-	warning_flags="-Wall -Wmissing-prototypes -Wbad-function-cast -Wcast-align -Wextra -Wformat-nonliteral -Wmissing-declarations -Wmissing-field-initializers -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Werror=format-security -Wno-sign-compare"
+	warning_flags="-Wall -Wmissing-prototypes -Wbad-function-cast -Wcast-align -Wextra -Wno-unused-parameter -Wformat-nonliteral -Wmissing-declarations -Wmissing-field-initializers -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Werror=format-security -Wno-sign-compare"
 	if test "$enable_compile_warnings" = "error" ; then
 	    warning_flags="$warning_flags -Werror"
 	fi


### PR DESCRIPTION
This will solve problems in several PRs.
https://github.com/mate-desktop/mate-panel/pull/1050
https://github.com/mate-desktop/mate-calc/pull/149
When local compiling it is possible to use `./autogen.sh CFLAGS='-Wunused-parameter'` to enable the warnings.
We can also add the `-Wunused-parameter` to travis config to see the warnings in travis logs, if you think this is needed for new PRs. But than new warnings should be fixed in PRs ;)

I hope this is a compromise for everyone in the team.