### PR TITLE
mate-compiler-flags: little changes

### DIFF
--- a/macros/mate-compiler-flags.m4
+++ b/macros/mate-compiler-flags.m4
@@ -49,7 +49,7 @@ AC_DEFUN([MATE_COMPILE_WARNINGS],[
 	warning_flags="-Wall -Wmissing-prototypes"
 	;;
     maximum|error)
-	warning_flags="-Wall -Wmissing-prototypes -Wbad-function-cast -Wcast-align -Wextra -Wno-unused-parameter -Wformat-nonliteral -Wmissing-declarations -Wmissing-field-initializers -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Werror=format-security -Wno-sign-compare"
+	warning_flags="-Wall -Wmissing-prototypes -Wbad-function-cast -Wcast-align -Wextra -Wno-unused-parameter -Wformat-nonliteral -Wmissing-declarations -Wmissing-field-initializers -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Werror=format-security"
 	if test "$enable_compile_warnings" = "error" ; then
 	    warning_flags="$warning_flags -Werror"
 	fi
@@ -107,10 +107,10 @@ AC_DEFUN([MATE_CXX_WARNINGS],[
 	warning_flags="-Wall"
 	;;
     yes)
-        warning_flags="-Wall -Wno-unused -Woverloaded-virtual"
+        warning_flags="-Wall -Woverloaded-virtual"
 	;;
     maximum|error)
-        warning_flags="-Wall -Wno-unused -Woverloaded-virtual -Wextra -Wshadow -Wformat-nonliteral -Werror=format-security -Wpointer-arith -Wno-sign-compare -Wcast-align -Wmissing-declarations -Wredundant-decls"
+        warning_flags="-Wall -Woverloaded-virtual -Wextra -Wshadow -Wformat-nonliteral -Werror=format-security -Wpointer-arith -Wcast-align -Wmissing-declarations -Wredundant-decls"
 	if test "$enable_compile_warnings" = "error" ; then
 	    warning_flags="$warning_flags -Werror"
 	fi

--- a/macros/mate-compiler-flags.m4
+++ b/macros/mate-compiler-flags.m4
@@ -110,7 +110,7 @@ AC_DEFUN([MATE_CXX_WARNINGS],[
         warning_flags="-Wall -Woverloaded-virtual"
 	;;
     maximum|error)
-        warning_flags="-Wall -Woverloaded-virtual -Wextra -Wshadow -Wformat-nonliteral -Werror=format-security -Wpointer-arith -Wcast-align -Wmissing-declarations -Wredundant-decls"
+        warning_flags="-Wall -Woverloaded-virtual -Wextra -Wshadow -Wformat-nonliteral -Werror=format-security -Wno-unused-parameter -Wpointer-arith -Wcast-align -Wmissing-declarations -Wredundant-decls"
 	if test "$enable_compile_warnings" = "error" ; then
 	    warning_flags="$warning_flags -Werror"
 	fi


### PR DESCRIPTION
If we can't see false positive warnings with this change, I think is good to add it to the maximum warning level.

If accepted, is not urgent to push new release in mate-common, it can be done later in the future.